### PR TITLE
Add palm speed activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,9 +58,12 @@
       position: absolute;
       top: 0;
       left: 0;
+      width: 100%;
       padding: 1vh;
       color: #fff;
       font-size: 2vh;
+      display: flex;
+      justify-content: space-between;
     }
   </style>
 
@@ -70,7 +73,7 @@
     <button id="start-btn">START</button>
   </section>
 
-  <section id="game-screen" class="screen"><div class="video-container"><canvas id="game-canvas"></canvas></div><div id="hud"><span id="timer"></span><span id="score" style="margin-left:20px"></span></div></section>
+  <section id="game-screen" class="screen"><div class="video-container"><video id="game-video" autoplay muted playsinline></video><canvas id="game-canvas"></canvas></div><div id="hud"><span id="timer"></span><span id="score"></span></div></section>
 
   <!-- External libraries for pose detection -->
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core"></script>

--- a/js/gameMode.js
+++ b/js/gameMode.js
@@ -10,7 +10,7 @@ export default class GameMode {
     this.scoreEl = document.getElementById('score');
     this.canvas = document.getElementById('game-canvas');
     this.ctx = this.canvas.getContext('2d');
-    this.video = document.getElementById('intro-video');
+    this.video = document.getElementById('game-video');
     this.pose = new PoseProcessor(this.video, this.canvas);
     this.time = 60;
     this.score = 0;
@@ -62,7 +62,7 @@ export default class GameMode {
       if (!f.alive) return;
       ['left', 'right'].forEach(side => {
         const h = hands[side];
-        if (!h || h.speed < 1000) return;
+        if (!h || !h.active) return;
         const dx = h.x - f.x;
         const dy = h.y - f.y;
         const dist = Math.hypot(dx, dy);
@@ -91,12 +91,13 @@ export default class GameMode {
       this.spawnTimer = 0;
     }
 
-    const hands = await this.pose.update(dt);
+    const hands = await this.pose.update(dt, false);
     this.fruits.forEach(f => f.update(dt));
     this.checkCollisions(hands);
 
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     this.fruits.forEach(f => f.draw(this.ctx));
+    this.pose.drawPalms(hands);
 
     this.updateDisplay();
     this.animationId = requestAnimationFrame(this.loop);

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -53,7 +53,7 @@ export default class StartMode {
       if (!h) return;
       const x = canvasRect.left + (h.x / this.canvas.width) * canvasRect.width;
       const y = canvasRect.top + (h.y / this.canvas.height) * canvasRect.height;
-      if (h.speed > 1000 && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+      if (h.active && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
         this.startGame();
       }
     });


### PR DESCRIPTION
## Summary
- color palms white or red depending on movement speed
- display webcam feed in game mode and draw palms
- start game when an active palm crosses the start button
- only active palms slice fruits
- show timer and score on opposite sides of the HUD

## Testing
- `node -v` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6842ace29ce08326a3393f6c6314e0a3