### PR TITLE
Fix canvas sizing after video loads

### DIFF
--- a/js/poseProcessor.js
+++ b/js/poseProcessor.js
@@ -21,6 +21,13 @@ export default class PoseProcessor {
       const stream = await navigator.mediaDevices.getUserMedia({ video: true });
       this.video.srcObject = stream;
       await this.video.play();
+
+      if (this.video.readyState < 1) {
+        await new Promise(resolve => {
+          this.video.addEventListener('loadedmetadata', resolve, { once: true });
+        });
+      }
+
       this.canvas.width = this.video.videoHeight * 4 / 3;
       this.canvas.height = this.video.videoHeight;
       if (DEBUG) console.log('Webcam started');


### PR DESCRIPTION
## Summary
- check for `loadedmetadata` after starting webcam
- size canvas only once video dimensions are known

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b4b54d8c83269494cadb8d38db7f