### PR TITLE
Mirror webcam feed and fruit start gesture

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,13 +39,17 @@
       height: 100%;
       object-fit: cover;
     }
-    #start-btn {
+    .video-container video {
+      transform: scaleX(-1);
+    }
+    #start-fruit {
       position: absolute;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      padding: 2vh 4vh;
-      font-size: 3vh;
+      width: 15vh;
+      height: 15vh;
+      pointer-events: none;
     }
     #game-canvas {
       position: absolute;
@@ -70,7 +74,7 @@
 </head>
 <body>
   <section id="start-screen" class="screen"><div class="video-container"><video id="intro-video" autoplay muted playsinline></video><canvas id="intro-canvas"></canvas></div>
-    <button id="start-btn">START</button>
+    <img id="start-fruit" src="fruit.png" alt="Start">
   </section>
 
   <section id="game-screen" class="screen"><div class="video-container"><video id="game-video" autoplay muted playsinline></video><canvas id="game-canvas"></canvas></div><div id="hud"><span id="timer"></span><span id="score"></span></div></section>

--- a/js/gameMode.js
+++ b/js/gameMode.js
@@ -70,6 +70,7 @@ export default class GameMode {
           f.alive = false;
           this.score += f.score;
           if (DEBUG) console.log('Fruit cut', f);
+          this.updateDisplay();
         }
       });
     });

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -7,7 +7,7 @@ export default class StartMode {
     this.container = document.getElementById('start-screen');
     this.video = document.getElementById('intro-video');
     this.canvas = document.getElementById('intro-canvas');
-    this.startBtn = document.getElementById('start-btn');
+    this.startFruit = document.getElementById('start-fruit');
     this.pose = new PoseProcessor(this.video, this.canvas);
     this.animationId = null;
     this.lastTime = 0;
@@ -17,7 +17,6 @@ export default class StartMode {
   async enter() {
     this.container.style.display = 'block';
     await this.pose.init();
-    this.startBtn.addEventListener('click', this.startGame);
     this.lastTime = performance.now();
     this.loop(this.lastTime);
     if (DEBUG) console.log('StartMode enter');
@@ -26,7 +25,6 @@ export default class StartMode {
   exit = () => {
     this.container.style.display = 'none';
     cancelAnimationFrame(this.animationId);
-    this.startBtn.removeEventListener('click', this.startGame);
     if (DEBUG) console.log('StartMode exit');
   };
 
@@ -46,7 +44,7 @@ export default class StartMode {
 
   checkStartCut(hands) {
     if (!hands) return;
-    const rect = this.startBtn.getBoundingClientRect();
+    const rect = this.startFruit.getBoundingClientRect();
     const canvasRect = this.canvas.getBoundingClientRect();
     ['left', 'right'].forEach(side => {
       const h = hands[side];


### PR DESCRIPTION
## Summary
- mirror webcam videos for natural hand orientation
- update game score immediately when fruit is cut
- replace button on start screen with a fruit image that must be sliced to begin

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843be6cb3b083268a11163969a9d55c