### PR TITLE
Add TIME_SPEED to slow fruit movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository now contains the initial structure of a pose‑controlled fruit 
 
 - **index.html** – loads external pose detection libraries and switches between different game modes.
 - **js/poseProcessor.js** – wrapper around pose detection library. Starts the webcam, estimates body pose and draws highlighted palms with speed information.
-- **js/config.js** – global configuration with a `DEBUG` flag and `USE_STUB` to simulate movement without a webcam.
+- **js/config.js** – global configuration with a `DEBUG` flag, `USE_STUB` to simulate movement without a webcam, and `TIME_SPEED` to scale physics.
 - **js/modeManager.js** – simple controller used to register and switch between modes.
 - **js/startMode.js** – displays the intro screen with live webcam feed. Cutting the start button with a fast hand movement begins the game.
 - **js/fruit.js** – small physics object representing a falling fruit.
@@ -23,4 +23,6 @@ Serve the repository over HTTP and open `index.html` in a modern browser. For ex
 
 The game scales all visuals according to the height of the video feed. The feed is cropped to a 4:3 ratio and displayed full-screen with black borders if necessary. If you set `USE_STUB` to `true` in `js/config.js`, the game will generate mock hand motion so you can test without a webcam. Enable `DEBUG` for verbose console logging from all modules.
 If the MoveNet model fails to load because of CORS restrictions, download the model files locally and update the paths in `js/poseProcessor.js`.
+
+Adjust `TIME_SPEED` in `js/config.js` to make fruits fall slower or faster without affecting the round timer.
 

--- a/js/config.js
+++ b/js/config.js
@@ -2,6 +2,9 @@ export const DEBUG = true; // enable debug logs
 export const USE_STUB = false; // use synthetic hand movement instead of webcam
 // Minimum confidence score for keypoints to be considered valid
 export const MIN_KP_SCORE = 0.2;
+// Multiplier for all in-game physics. Values below 1 slow the action down
+// while values above 1 speed it up. Game time shown to the user is not affected.
+export const TIME_SPEED = 0.5;
 
 export function debug(...args) {
   if (DEBUG) {

--- a/js/gameMode.js
+++ b/js/gameMode.js
@@ -1,6 +1,6 @@
 import PoseProcessor from './poseProcessor.js';
 import Fruit from './fruit.js';
-import { DEBUG, debug } from './config.js';
+import { DEBUG, debug, TIME_SPEED } from './config.js';
 
 export default class GameMode {
   constructor(manager) {
@@ -78,20 +78,20 @@ export default class GameMode {
   }
 
   loop = async (timestamp) => {
-    const dt = (timestamp - this.lastTime) / 1000;
+    const realDt = (timestamp - this.lastTime) / 1000;
     this.lastTime = timestamp;
-    this.time -= dt;
+    this.time -= realDt;
     if (this.time <= 0) {
       this.manager.switchTo('start');
       return;
     }
-    this.spawnTimer += dt;
+    this.spawnTimer += realDt;
     if (this.spawnTimer > 1) {
       this.spawnFruit();
       this.spawnTimer = 0;
     }
-
-    const hands = await this.pose.update(dt, false);
+    const dt = realDt * TIME_SPEED;
+    const hands = await this.pose.update(realDt, false);
     this.fruits.forEach(f => f.update(dt));
     this.checkCollisions(hands);
 

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -1,5 +1,5 @@
 import PoseProcessor from './poseProcessor.js';
-import { DEBUG, debug } from './config.js';
+import { DEBUG, debug, TIME_SPEED } from './config.js';
 
 export default class StartMode {
   constructor(manager) {
@@ -35,9 +35,9 @@ export default class StartMode {
   };
 
   loop = async (timestamp) => {
-    const dt = (timestamp - this.lastTime) / 1000;
+    const realDt = (timestamp - this.lastTime) / 1000;
     this.lastTime = timestamp;
-    const hands = await this.pose.update(dt);
+    const hands = await this.pose.update(realDt);
     this.checkStartCut(hands);
     this.animationId = requestAnimationFrame(this.loop);
   };


### PR DESCRIPTION
## Summary
- add `TIME_SPEED` constant in `config.js`
- apply the physics speed multiplier in `GameMode`
- keep real-time countdown and hand tracking updates
- adjust `StartMode` to import config
- document new option in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684516b2b50483269a3ea0a83cb9ff12