### PR TITLE
Adjust fruit physics to maintain visible parabolic flight

### DIFF
--- a/js/fruit.js
+++ b/js/fruit.js
@@ -1,7 +1,7 @@
 import { DEBUG, debug } from './config.js';
 
 export default class Fruit {
-  constructor(image, x, y, vx, vy, radius, score = 1) {
+  constructor(image, x, y, vx, vy, radius, score = 1, canvasWidth = null) {
     this.image = new Image();
     this.image.src = image;
     this.x = x;
@@ -12,6 +12,17 @@ export default class Fruit {
     this.radius = radius;
     this.score = score;
     this.alive = true;
+    this.highestY = null;
+    this.endVy = null;
+
+    if (canvasWidth !== null) {
+      const tPeak = -this.vy / this.gravity;
+      this.highestY = this.y + this.vy * tPeak + 0.5 * this.gravity * tPeak ** 2;
+      const distX = canvasWidth + this.radius * 2;
+      const tCross = distX / Math.abs(this.vx);
+      this.endVy = this.vy + this.gravity * tCross;
+    }
+
     debug('Fruit created', this);
   }
 

--- a/js/gameMode.js
+++ b/js/gameMode.js
@@ -46,13 +46,31 @@ export default class GameMode {
   }
 
   spawnFruit() {
-    const side = Math.random() < 0.5 ? 'left' : 'right';
-    const x = side === 'left' ? -this.canvas.height * 0.05 : this.canvas.width + this.canvas.height * 0.05;
-    const y = Math.random() * this.canvas.height * 0.5;
-    const vx = side === 'left' ? 200 + Math.random() * 200 : -200 - Math.random() * 200;
-    const vy = -600 - Math.random() * 200;
     const radius = this.canvas.height * 0.05;
-    const fruit = new Fruit('fruit.png', x, y, vx, vy, radius);
+    const side = Math.random() < 0.5 ? 'left' : 'right';
+    const x = side === 'left' ? -radius : this.canvas.width + radius;
+
+    const vxMag = 200 + Math.random() * 200;
+    const vx = side === 'left' ? vxMag : -vxMag;
+
+    // choose peak between 10% and 45% of the screen height
+    const peakMin = this.canvas.height * 0.1;
+    const peakMax = this.canvas.height * 0.45;
+    const highestY = peakMin + Math.random() * (peakMax - peakMin);
+
+    const y = highestY + Math.random() * (this.canvas.height * 0.5 - highestY);
+
+    const g = 800;
+    const vy = -Math.sqrt(2 * g * (y - highestY));
+
+    const distX = this.canvas.width + radius * 2;
+    const tCross = distX / vxMag;
+    const endVy = vy + g * tCross;
+
+    const fruit = new Fruit('fruit.png', x, y, vx, vy, radius, 1, this.canvas.width);
+    fruit.highestY = highestY;
+    fruit.endVy = endVy;
+
     this.fruits.push(fruit);
     debug('Spawn fruit', fruit);
   }


### PR DESCRIPTION
## Summary
- compute trajectory parameters when a fruit is spawned
- store highest point and speed at opposite screen edge in `Fruit`
- spawn fruits using calculated vertical speed so they stay on screen

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `node -c js/gameMode.js`
- `node -c js/fruit.js`


------
https://chatgpt.com/codex/tasks/task_e_684521fdabc88326a6e1f2a2b606f0aa