### PR TITLE
Add fruit and level configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This repository now contains the initial structure of a pose‑controlled fruit 
 
 - **index.html** – loads external pose detection libraries and switches between different game modes.
 - **js/poseProcessor.js** – wrapper around pose detection library. Initializes the webcam stream and pose detector once and draws highlighted palms with speed information.
-- **js/config.js** – global configuration with a `DEBUG` flag, `USE_STUB` to simulate movement without a webcam, and `TIME_SPEED` to scale physics.
+- **js/config.js** – global configuration with a `DEBUG` flag and `USE_STUB` to simulate movement without a webcam.
+- **js/fruitConfig.js** – list of available fruits with image, score and size information.
+- **js/levelConfig.js** – game levels defining speed and prioritized fruit choices.
 - **js/modeManager.js** – simple controller used to register and switch between modes.
 - **js/startMode.js** – displays the intro screen with live webcam feed. Cutting the start button with a fast hand movement begins the game.
 - **js/fruit.js** – small physics object representing a falling fruit.
@@ -24,5 +26,5 @@ Serve the repository over HTTP and open `index.html` in a modern browser. For ex
 The game scales all visuals according to the height of the video feed. The feed is cropped to a 4:3 ratio and displayed full-screen with black borders if necessary. If you set `USE_STUB` to `true` in `js/config.js`, the game will generate mock hand motion so you can test without a webcam. Enable `DEBUG` for verbose console logging from all modules.
 If the MoveNet model fails to load because of CORS restrictions, download the model files locally and update the paths in `js/poseProcessor.js`.
 
-Adjust `TIME_SPEED` in `js/config.js` to make fruits fall slower or faster without affecting the round timer. The webcam stream and pose detector are kept alive across modes so they only need to initialize once.
+Edit `js/levelConfig.js` to tweak the game speed or change which fruits appear in each level. The webcam stream and pose detector are kept alive across modes so they only need to initialize once.
 

--- a/js/config.js
+++ b/js/config.js
@@ -2,9 +2,6 @@ export const DEBUG = true; // enable debug logs
 export const USE_STUB = false; // use synthetic hand movement instead of webcam
 // Minimum confidence score for keypoints to be considered valid
 export const MIN_KP_SCORE = 0.15;
-// Multiplier for all in-game physics. Values below 1 slow the action down
-// while values above 1 speed it up. Game time shown to the user is not affected.
-export const TIME_SPEED = 0.2;
 
 export function debug(...args) {
   if (DEBUG) {

--- a/js/fruitConfig.js
+++ b/js/fruitConfig.js
@@ -1,0 +1,8 @@
+export const FRUITS = {
+  basic: {
+    image: 'fruit.png',
+    name: 'Fruit',
+    score: 1,
+    size: 0.1, // fraction of screen height for diameter
+  },
+};

--- a/js/gameMode.js
+++ b/js/gameMode.js
@@ -1,10 +1,12 @@
 import PoseProcessor from './poseProcessor.js';
 import Fruit from './fruit.js';
-import { DEBUG, debug, TIME_SPEED } from './config.js';
+import { DEBUG, debug } from './config.js';
+import { LEVELS, chooseFruit } from './levelConfig.js';
 
 export default class GameMode {
-  constructor(manager) {
+  constructor(manager, level = 0) {
     this.manager = manager;
+    this.level = level;
     this.container = document.getElementById('game-screen');
     this.timerEl = document.getElementById('timer');
     this.scoreEl = document.getElementById('score');
@@ -18,6 +20,7 @@ export default class GameMode {
     this.spawnTimer = 0;
     this.animationId = null;
     this.lastTime = 0;
+    this.timeSpeed = LEVELS[this.level].speed;
     debug('GameMode created');
   }
 
@@ -45,12 +48,13 @@ export default class GameMode {
   }
 
   spawnFruit() {
+    const cfg = chooseFruit(this.level);
     // Spawn from either side and calculate a parabolic trajectory.
     // 1) pick a random side and starting height
     // 2) choose a peak higher than the start
     // 3) pick a point where the fruit will cross the bottom
     //    (0.5-1.5 screen widths away) and derive velocities
-    const radius = this.canvas.height * 0.05;
+    const radius = this.canvas.height * (cfg.size / 2);
     const side = Math.random() < 0.5 ? 'left' : 'right';
     const x = side === 'left' ? -radius : this.canvas.width + radius;
 
@@ -79,7 +83,7 @@ export default class GameMode {
     const vx = (fallX - x) / tCross;
     const endVy = vy + g * tCross;
 
-    const fruit = new Fruit('fruit.png', x, startY, vx, vy, radius, 1, this.canvas.width);
+    const fruit = new Fruit(cfg.image, x, startY, vx, vy, radius, cfg.score, this.canvas.width);
     fruit.highestY = highestY;
     fruit.endVy = endVy;
 
@@ -120,7 +124,7 @@ export default class GameMode {
       this.spawnFruit();
       this.spawnTimer = 0;
     }
-    const dt = realDt * TIME_SPEED;
+    const dt = realDt * this.timeSpeed;
     const hands = await this.pose.update(realDt, false);
     this.fruits.forEach(f => f.update(dt));
     this.checkCollisions(hands);

--- a/js/levelConfig.js
+++ b/js/levelConfig.js
@@ -1,0 +1,22 @@
+import { FRUITS } from './fruitConfig.js';
+
+export const LEVELS = [
+  {
+    speed: 0.2,
+    fruits: [
+      { type: 'basic', priority: 1 },
+    ],
+  },
+];
+
+// utility to pick a fruit based on priorities
+export function chooseFruit(level) {
+  const list = LEVELS[level].fruits;
+  const total = list.reduce((s, f) => s + f.priority, 0);
+  let r = Math.random() * total;
+  for (const f of list) {
+    if (r < f.priority) return FRUITS[f.type];
+    r -= f.priority;
+  }
+  return FRUITS[list[0].type];
+}

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -1,5 +1,5 @@
 import PoseProcessor from './poseProcessor.js';
-import { DEBUG, debug, TIME_SPEED } from './config.js';
+import { DEBUG, debug } from './config.js';
 
 export default class StartMode {
   constructor(manager) {


### PR DESCRIPTION
## Summary
- add `fruitConfig.js` with base fruit definition
- add `levelConfig.js` with level speed and prioritized fruit choice
- use new level config in `GameMode` and remove `TIME_SPEED`
- drop unused constant from `config.js`
- document new files and update instructions in README
- rename `weight` field to `priority`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68453f7c63508326a263b8c901302cf1