### PR TITLE
Use fruit config for start screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This repository now contains the initial structure of a pose‑controlled fruit 
 - **js/startMode.js** – displays the intro screen with live webcam feed. Cutting the start button with a fast hand movement begins the game.
 - **js/fruit.js** – small physics object representing a falling fruit.
 - **js/gameMode.js** – real‑time game loop that updates the timer, fruits and palm positions every frame.
-- **fruit.png** – image used for spawned fruits.
+- **img/** – folder with fruit images. The `basic` entry in `js/fruitConfig.js`
+  provides the image used for the start button.
 
 The code is written in small modules so that additional modes (for example a score screen or settings) can be added later by registering new mode classes with `ModeManager`.
 

--- a/index.html
+++ b/index.html
@@ -47,8 +47,6 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      width: 15vh;
-      height: 15vh;
       pointer-events: none;
     }
     #game-canvas {
@@ -75,7 +73,7 @@
 </head>
 <body>
   <section id="start-screen" class="screen"><div class="video-container"><video id="intro-video" autoplay muted playsinline></video><canvas id="intro-canvas"></canvas></div>
-    <img id="start-fruit" src="fruit.png" alt="Start">
+    <img id="start-fruit" alt="Start">
   </section>
 
   <section id="game-screen" class="screen"><div class="video-container"><video id="game-video" autoplay muted playsinline></video><canvas id="game-canvas"></canvas></div><div id="hud"><span id="timer"></span><span id="score"></span></div></section>

--- a/js/fruitConfig.js
+++ b/js/fruitConfig.js
@@ -1,32 +1,27 @@
 export const FRUITS = {
   basic: {
     image: 'img/watermelon.png',
-    name: 'watermelon',
     score: 1,
-    size: 0.2, 
+    size: 0.2,
   },
   apple: {
     image: 'img/apple.png',
-    name: 'apple',
     score: 2,
     size: 0.13, // fraction of screen height
   },
   pear: {
     image: 'img/pear.png',
-    name: 'pear',
     score: 3,
     size: 0.15, // fraction of screen height
   },
   mandarine: {
     image: 'img/mandarine.png',
-    name: 'mandarine',
     score: 4,
     size: 0.1, // fraction of screen height
   },
   pineapple: {
     image: 'img/pineapple.png',
-    name: 'pineapple',
     score: 1,
     size: 0.2,
-  },  
+  },
 };

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -1,5 +1,6 @@
 import PoseProcessor from './poseProcessor.js';
 import { DEBUG, debug } from './config.js';
+import { FRUITS } from './fruitConfig.js';
 
 export default class StartMode {
   constructor(manager) {
@@ -8,6 +9,11 @@ export default class StartMode {
     this.video = document.getElementById('intro-video');
     this.canvas = document.getElementById('intro-canvas');
     this.startFruit = document.getElementById('start-fruit');
+    // Use the image and configured size of the basic fruit for the start button
+    this.startFruit.src = FRUITS.basic.image;
+    const size = `${FRUITS.basic.size * 100}vh`;
+    this.startFruit.style.width = size;
+    this.startFruit.style.height = size;
     this.pose = new PoseProcessor(this.video, this.canvas);
     this.animationId = null;
     this.lastTime = 0;


### PR DESCRIPTION
## Summary
- update start button to use the basic fruit's image and size
- remove unused `name` field from `fruitConfig`
- note fruit images folder in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68454550a8a483269ebd8e66f023358c