### PR TITLE
Implement level completion screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,25 @@
       width: 100%;
       height: 100%;
     }
+    #complete-text {
+      position: absolute;
+      top: 35%;
+      width: 100%;
+      text-align: center;
+      color: #fff;
+      font-size: 5vh;
+    }
+    #final-score {
+      font-size: 8vh;
+      margin-top: 2vh;
+    }
+    #continue-fruit {
+      position: absolute;
+      bottom: 5vh;
+      left: 50%;
+      transform: translateX(-50%);
+      pointer-events: none;
+    }
     #hud {
       position: absolute;
       top: 0;
@@ -78,6 +97,18 @@
 
   <section id="game-screen" class="screen"><div class="video-container"><video id="game-video" autoplay muted playsinline></video><canvas id="game-canvas"></canvas></div><div id="hud"><span id="timer"></span><span id="score"></span></div></section>
 
+  <section id="complete-screen" class="screen">
+    <div class="video-container">
+      <video id="complete-video" autoplay muted playsinline></video>
+      <canvas id="complete-canvas"></canvas>
+    </div>
+    <div id="complete-text">
+      <div id="level-finished"></div>
+      <div id="final-score"></div>
+    </div>
+    <img id="continue-fruit" alt="Continue">
+  </section>
+
   <!-- External libraries for pose detection -->
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core"></script>
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter"></script>
@@ -88,13 +119,16 @@
     import ModeManager from './js/modeManager.js';
     import StartMode from './js/startMode.js';
     import GameMode from './js/gameMode.js';
+    import LevelCompleteMode from './js/levelCompleteMode.js';
 
     const manager = new ModeManager();
     const start = new StartMode(manager);
     const game = new GameMode(manager);
+    const complete = new LevelCompleteMode(manager);
 
     manager.register('start', start);
     manager.register('game', game);
+    manager.register('complete', complete);
 
     manager.switchTo('start');
   </script>

--- a/js/modeManager.js
+++ b/js/modeManager.js
@@ -4,6 +4,8 @@ export default class ModeManager {
   constructor() {
     this.modes = {};
     this.current = null;
+    this.level = 0;
+    this.lastScore = 0;
     debug('ModeManager created');
   }
 

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -31,11 +31,14 @@ export default class StartMode {
   exit = () => {
     this.container.style.display = 'none';
     cancelAnimationFrame(this.animationId);
+    this.pose.stop();
     debug('StartMode exit');
   };
 
   startGame = () => {
     debug('Switching to game');
+    this.manager.level = 0;
+    this.manager.lastScore = 0;
     this.manager.switchTo('game');
   };
 


### PR DESCRIPTION
## Summary
- add LevelCompleteMode for level finish handling
- show score screen with continue fruit
- track level in ModeManager and allow multi-level progression
- adjust GameMode logic for end-of-level flow
- wire up new mode and styles in index.html

## Testing
- `node -e "console.log('Node works')"`

------
https://chatgpt.com/codex/tasks/task_e_6845667eed7c8326a05b2ff079acc6ee