### PR TITLE
Improve UI text background and wait on continue

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,9 @@
       text-align: center;
       color: #fff;
       font-size: 5vh;
+      background: rgba(0, 64, 0, 0.6);
+      padding: 1vh;
+      box-sizing: border-box;
     }
     #game-canvas {
       position: absolute;
@@ -71,6 +74,9 @@
       text-align: center;
       color: #fff;
       font-size: 5vh;
+      background: rgba(0, 64, 0, 0.6);
+      padding: 1vh;
+      box-sizing: border-box;
     }
     #final-score {
       font-size: 8vh;
@@ -96,7 +102,7 @@
       justify-content: space-between;
     }
     #hud span {
-      background: rgba(0, 0, 0, 0.5);
+      background: rgba(0, 64, 0, 0.6);
       padding: 0.5vh 1vh;
       border-radius: 1vh;
     }

--- a/js/levelCompleteMode.js
+++ b/js/levelCompleteMode.js
@@ -19,6 +19,8 @@ export default class LevelCompleteMode {
     this.pose = new PoseProcessor(this.video, this.canvas);
     this.animationId = null;
     this.lastTime = 0;
+    this.buttonReady = false;
+    this.showTimeout = null;
     debug('LevelCompleteMode created');
   }
 
@@ -32,6 +34,12 @@ export default class LevelCompleteMode {
       this.levelLabel.textContent = `Level ${levelNum} finished`;
     }
     this.scoreLabel.textContent = `Score: ${this.manager.lastScore}`;
+    this.continueFruit.style.visibility = 'hidden';
+    this.buttonReady = false;
+    this.showTimeout = setTimeout(() => {
+      this.continueFruit.style.visibility = 'visible';
+      this.buttonReady = true;
+    }, 1000);
     this.lastTime = performance.now();
     this.loop(this.lastTime);
     debug('LevelCompleteMode enter');
@@ -40,6 +48,7 @@ export default class LevelCompleteMode {
   exit = () => {
     this.container.style.display = 'none';
     cancelAnimationFrame(this.animationId);
+    clearTimeout(this.showTimeout);
     this.pose.stop();
     debug('LevelCompleteMode exit');
   };
@@ -65,7 +74,7 @@ export default class LevelCompleteMode {
   };
 
   checkCut(hands) {
-    if (!hands) return;
+    if (!this.buttonReady || !hands) return;
     const rect = this.continueFruit.getBoundingClientRect();
     const canvasRect = this.canvas.getBoundingClientRect();
     ['left', 'right'].forEach(side => {


### PR DESCRIPTION
## Summary
- add semi transparent dark green background to HUD, start text and intermediate screen text
- delay the continue fruit for 1s when level screen starts so previous hand movement does not trigger it

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684571bba3e483269d4e8891161d9057