### PR TITLE
Add level timing and Poisson spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository now contains the initial structure of a pose‑controlled fruit 
 - **js/poseProcessor.js** – wrapper around pose detection library. Initializes the webcam stream and pose detector once and draws highlighted palms.
 - **js/config.js** – global configuration with a `DEBUG` flag, `USE_STUB` to simulate movement without a webcam and `ACTIVE_SPEED_FRACTION` controlling how fast a hand must move to become active.
 - **js/fruitConfig.js** – list of available fruits with image, score and size information.
-- **js/levelConfig.js** – game levels defining speed and prioritized fruit choices.
+- **js/levelConfig.js** – game levels defining speed, duration, spawn rate and prioritized fruit choices.
 - **js/modeManager.js** – simple controller used to register and switch between modes.
 - **js/startMode.js** – displays the intro screen with live webcam feed. Cutting the start button with a fast hand movement begins the game.
 - **js/fruit.js** – small physics object representing a falling fruit.
@@ -22,10 +22,10 @@ The code is written in small modules so that additional modes (for example a sco
 
 ## Running
 
-Serve the repository over HTTP and open `index.html` in a modern browser. For example you can run `npx serve` from the project root. The page will request webcam permissions and show the start screen. Fast palm movements are detected using pose estimation. Slice through the start button with a quick hand motion to begin. During the 60 second round, fruits spawn from the sides of the screen and fall with gravity. Cutting them by moving your hand quickly across a fruit awards score.
+Serve the repository over HTTP and open `index.html` in a modern browser. For example you can run `npx serve` from the project root. The page will request webcam permissions and show the start screen. Fast palm movements are detected using pose estimation. Slice through the start button with a quick hand motion to begin. Each level defines its own duration and how many fruits appear per second. During the round fruits spawn from the sides of the screen following a Poisson distribution and fall with gravity. Cutting them by moving your hand quickly across a fruit awards score.
 
 The game scales all visuals according to the height of the video feed. The feed is cropped to a 4:3 ratio and displayed full-screen with black borders if necessary. If you set `USE_STUB` to `true` in `js/config.js`, the game will generate mock hand motion so you can test without a webcam. Enable `DEBUG` for verbose console logging from all modules.
 If the MoveNet model fails to load because of CORS restrictions, download the model files locally and update the paths in `js/poseProcessor.js`.
 
-Edit `js/levelConfig.js` to tweak the game speed or change which fruits appear in each level. The webcam stream and pose detector are kept alive across modes so they only need to initialize once.
+Edit `js/levelConfig.js` to tweak the game speed, duration, spawn rate or change which fruits appear in each level. The webcam stream and pose detector are kept alive across modes so they only need to initialize once.
 

--- a/js/levelConfig.js
+++ b/js/levelConfig.js
@@ -2,6 +2,8 @@ import { FRUITS } from './fruitConfig.js';
 
 export const LEVELS = [
   {
+    time: 60,
+    fruitsPerSecond: 1,
     speed: 0.5,
     fruits: [
       { type: 'pineapple', priority: 5 },
@@ -11,6 +13,8 @@ export const LEVELS = [
   },
   
   {
+    time: 60,
+    fruitsPerSecond: 1.2,
     speed: 0.6,
     fruits: [
       { type: 'pineapple', priority: 2 },
@@ -19,8 +23,10 @@ export const LEVELS = [
       { type: 'mandarine', priority: 0.1 },
     ],
   },
-  
+
   {
+    time: 60,
+    fruitsPerSecond: 1.4,
     speed: 0.7,
     fruits: [
       { type: 'pineapple', priority: 1 },
@@ -28,9 +34,11 @@ export const LEVELS = [
       { type: 'apple', priority: 2 },
       { type: 'mandarine', priority: 0.5 },
     ],
-  },    
+  },
 
   {
+    time: 60,
+    fruitsPerSecond: 1.6,
     speed: 0.8,
     fruits: [
       { type: 'pineapple', priority: 1 },
@@ -38,9 +46,11 @@ export const LEVELS = [
       { type: 'apple', priority: 2 },
       { type: 'mandarine', priority: 1 },
     ],
-  },    
+  },
 
   {
+    time: 60,
+    fruitsPerSecond: 1.8,
     speed: 0.9,
     fruits: [
       { type: 'pineapple', priority: 1 },


### PR DESCRIPTION
## Summary
- allow configuring level duration and fruit spawn rate
- update GameMode to use level time and Poisson-based spawning
- document new options in README
- fix spawn algorithm to use accumulated time properly

## Testing
- `node --check js/levelConfig.js`
- `node --check js/gameMode.js`


------
https://chatgpt.com/codex/tasks/task_e_684572f1f4708326a7067307e7de6cbf