### PR TITLE
Improve intersection checking using motion lines

### DIFF
--- a/js/fruit.js
+++ b/js/fruit.js
@@ -10,6 +10,8 @@ export default class Fruit {
     this.image.src = image;
     this.x = x;
     this.y = y;
+    this.prevX = x;
+    this.prevY = y;
     this.vx = vx;
     this.vy = vy;
     this.gravity = 800; // px per second^2
@@ -35,6 +37,8 @@ export default class Fruit {
   }
 
   update(dt) {
+    this.prevX = this.x;
+    this.prevY = this.y;
     this.vy += this.gravity * dt;
     this.x += this.vx * dt;
     this.y += this.vy * dt;

--- a/js/gameMode.js
+++ b/js/gameMode.js
@@ -2,6 +2,7 @@ import PoseProcessor from './poseProcessor.js';
 import Fruit from './fruit.js';
 import { DEBUG, debug } from './config.js';
 import { LEVELS, chooseFruit } from './levelConfig.js';
+import { segmentsClose } from './geometry.js';
 
 function samplePoisson(lambda) {
   const L = Math.exp(-lambda);
@@ -111,15 +112,18 @@ export default class GameMode {
   }
 
   checkCollisions(hands) {
+    const palmR = this.canvas.height * 0.03;
     this.fruits.forEach(f => {
       if (!f.alive) return;
       ['left', 'right'].forEach(side => {
         const h = hands[side];
         if (!h || !h.active) return;
-        const dx = h.x - f.x;
-        const dy = h.y - f.y;
-        const dist = Math.hypot(dx, dy);
-        if (dist < f.radius + 20) {
+        const p1 = { x: h.prevX, y: h.prevY };
+        const p2 = { x: h.x, y: h.y };
+        const f1 = { x: f.prevX, y: f.prevY };
+        const f2 = { x: f.x, y: f.y };
+        const radius = f.radius + palmR;
+        if (segmentsClose(p1, p2, f1, f2, radius)) {
           f.alive = false;
           this.score += f.score;
           debug('Fruit cut', f);

--- a/js/geometry.js
+++ b/js/geometry.js
@@ -1,0 +1,64 @@
+export function orientation(p, q, r) {
+  return (q.y - p.y) * (r.x - q.x) - (q.x - p.x) * (r.y - q.y);
+}
+
+export function onSegment(p, q, r) {
+  return Math.min(p.x, r.x) <= q.x && q.x <= Math.max(p.x, r.x) &&
+         Math.min(p.y, r.y) <= q.y && q.y <= Math.max(p.y, r.y);
+}
+
+export function segmentsIntersect(a1, a2, b1, b2) {
+  const o1 = orientation(a1, a2, b1);
+  const o2 = orientation(a1, a2, b2);
+  const o3 = orientation(b1, b2, a1);
+  const o4 = orientation(b1, b2, a2);
+
+  if (o1 * o2 < 0 && o3 * o4 < 0) return true;
+  if (o1 === 0 && onSegment(a1, b1, a2)) return true;
+  if (o2 === 0 && onSegment(a1, b2, a2)) return true;
+  if (o3 === 0 && onSegment(b1, a1, b2)) return true;
+  if (o4 === 0 && onSegment(b1, a2, b2)) return true;
+  return false;
+}
+
+export function pointSegmentDistance(px, py, x1, y1, x2, y2) {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) return Math.hypot(px - x1, py - y1);
+  let t = ((px - x1) * dx + (py - y1) * dy) / lenSq;
+  t = Math.max(0, Math.min(1, t));
+  const cx = x1 + t * dx;
+  const cy = y1 + t * dy;
+  return Math.hypot(px - cx, py - cy);
+}
+
+export function segmentsClose(a1, a2, b1, b2, radius) {
+  if (segmentsIntersect(a1, a2, b1, b2)) return true;
+  const d1 = pointSegmentDistance(a1.x, a1.y, b1.x, b1.y, b2.x, b2.y);
+  const d2 = pointSegmentDistance(a2.x, a2.y, b1.x, b1.y, b2.x, b2.y);
+  const d3 = pointSegmentDistance(b1.x, b1.y, a1.x, a1.y, a2.x, a2.y);
+  const d4 = pointSegmentDistance(b2.x, b2.y, a1.x, a1.y, a2.x, a2.y);
+  const minDist = Math.min(d1, d2, d3, d4);
+  return minDist <= radius;
+}
+
+export function pointInRect(p, rect) {
+  return p.x >= rect.left && p.x <= rect.right && p.y >= rect.top && p.y <= rect.bottom;
+}
+
+export function segmentRectIntersect(p1, p2, rect, radius = 0) {
+  if (pointInRect(p1, rect) || pointInRect(p2, rect)) return true;
+  const corners = [
+    { x: rect.left, y: rect.top },
+    { x: rect.right, y: rect.top },
+    { x: rect.right, y: rect.bottom },
+    { x: rect.left, y: rect.bottom },
+  ];
+  for (let i = 0; i < 4; i++) {
+    const a = corners[i];
+    const b = corners[(i + 1) % 4];
+    if (segmentsClose(p1, p2, a, b, radius)) return true;
+  }
+  return false;
+}

--- a/js/levelCompleteMode.js
+++ b/js/levelCompleteMode.js
@@ -2,6 +2,7 @@ import PoseProcessor from './poseProcessor.js';
 import { FRUITS } from './fruitConfig.js';
 import { LEVELS } from './levelConfig.js';
 import { debug } from './config.js';
+import { segmentRectIntersect } from './geometry.js';
 
 export default class LevelCompleteMode {
   constructor(manager) {
@@ -80,9 +81,11 @@ export default class LevelCompleteMode {
     ['left', 'right'].forEach(side => {
       const h = hands[side];
       if (!h) return;
-      const x = canvasRect.left + (h.x / this.canvas.width) * canvasRect.width;
-      const y = canvasRect.top + (h.y / this.canvas.height) * canvasRect.height;
-      if (h.active && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+      const x1 = canvasRect.left + (h.prevX / this.canvas.width) * canvasRect.width;
+      const y1 = canvasRect.top + (h.prevY / this.canvas.height) * canvasRect.height;
+      const x2 = canvasRect.left + (h.x / this.canvas.width) * canvasRect.width;
+      const y2 = canvasRect.top + (h.y / this.canvas.height) * canvasRect.height;
+      if (h.active && segmentRectIntersect({x: x1, y: y1}, {x: x2, y: y2}, rect)) {
         this.handleContinue();
       }
     });

--- a/js/poseProcessor.js
+++ b/js/poseProcessor.js
@@ -66,15 +66,28 @@ export default class PoseProcessor {
 
   drawPalms(hands) {
     if (!hands) return;
+    const r = this.canvas.height * 0.03;
     ['left', 'right'].forEach(side => {
       const h = hands[side];
       if (!h) return;
-      const r = this.canvas.height * 0.03;
-      this.ctx.fillStyle = h.active ? 'rgba(255,0,0,0.7)' : 'rgba(255,255,255,0.7)';
+      const color = h.active ? 'rgba(255,0,0,0.7)' : 'rgba(255,255,255,0.7)';
+      // draw previous position
+      this.ctx.fillStyle = color;
+      this.ctx.beginPath();
+      this.ctx.arc(h.prevX, h.prevY, r, 0, Math.PI * 2);
+      this.ctx.fill();
+      // draw connecting segment
+      this.ctx.strokeStyle = color;
+      this.ctx.lineWidth = r * 2;
+      this.ctx.lineCap = 'round';
+      this.ctx.beginPath();
+      this.ctx.moveTo(h.prevX, h.prevY);
+      this.ctx.lineTo(h.x, h.y);
+      this.ctx.stroke();
+      // draw current position
       this.ctx.beginPath();
       this.ctx.arc(h.x, h.y, r, 0, Math.PI * 2);
       this.ctx.fill();
-      // Palm speed is no longer displayed
     });
   }
 
@@ -112,20 +125,22 @@ export default class PoseProcessor {
 
     const hands = { left: null, right: null };
     if (left) {
+      const prev = this.prevLeft || left;
       const v = this.prevLeft && dt > 0 ? {
         vx: (left.x - this.prevLeft.x) / dt,
         vy: (left.y - this.prevLeft.y) / dt
       } : { vx: 0, vy: 0 };
       const speed = Math.hypot(v.vx, v.vy);
-      hands.left = { ...left, ...v, speed, active: speed > threshold };
+      hands.left = { ...left, ...v, speed, active: speed > threshold, prevX: prev.x, prevY: prev.y };
     }
     if (right) {
+      const prev = this.prevRight || right;
       const v = this.prevRight && dt > 0 ? {
         vx: (right.x - this.prevRight.x) / dt,
         vy: (right.y - this.prevRight.y) / dt
       } : { vx: 0, vy: 0 };
       const speed = Math.hypot(v.vx, v.vy);
-      hands.right = { ...right, ...v, speed, active: speed > threshold };
+      hands.right = { ...right, ...v, speed, active: speed > threshold, prevX: prev.x, prevY: prev.y };
     }
 
     this.prevLeft = left;

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -1,6 +1,7 @@
 import PoseProcessor from './poseProcessor.js';
 import { DEBUG, debug } from './config.js';
 import { FRUITS } from './fruitConfig.js';
+import { segmentRectIntersect } from './geometry.js';
 
 export default class StartMode {
   constructor(manager) {
@@ -59,9 +60,11 @@ export default class StartMode {
     ['left', 'right'].forEach(side => {
       const h = hands[side];
       if (!h) return;
-      const x = canvasRect.left + (h.x / this.canvas.width) * canvasRect.width;
-      const y = canvasRect.top + (h.y / this.canvas.height) * canvasRect.height;
-      if (h.active && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+      const x1 = canvasRect.left + (h.prevX / this.canvas.width) * canvasRect.width;
+      const y1 = canvasRect.top + (h.prevY / this.canvas.height) * canvasRect.height;
+      const x2 = canvasRect.left + (h.x / this.canvas.width) * canvasRect.width;
+      const y2 = canvasRect.top + (h.y / this.canvas.height) * canvasRect.height;
+      if (h.active && segmentRectIntersect({x: x1, y: y1}, {x: x2, y: y2}, rect)) {
         this.startGame();
       }
     });


### PR DESCRIPTION
## Summary
- add utilities for geometric intersections
- track previous positions on fruits
- include previous hand positions in pose processor results
- detect cutting on start and complete screens using line checks
- check collisions using motion segments
- draw palm motion segments for fast movement

## Testing
- `node --check js/geometry.js`
- `node --check js/poseProcessor.js`
- `node --check js/gameMode.js`
- `node --check js/startMode.js`
- `node --check js/levelCompleteMode.js`


------
https://chatgpt.com/codex/tasks/task_e_68490556c8d48326b954563401227e35