### PR TITLE
Preserve fruit aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ This repository now contains the initial structure of a pose‑controlled fruit 
 - **index.html** – loads external pose detection libraries and switches between different game modes.
 - **js/poseProcessor.js** – wrapper around pose detection library. Initializes the webcam stream and pose detector once and draws highlighted palms.
 - **js/config.js** – global configuration with a `DEBUG` flag, `USE_STUB` to simulate movement without a webcam and `ACTIVE_SPEED_FRACTION` controlling how fast a hand must move to become active.
-- **js/fruitConfig.js** – list of available fruits with image, score and size information.
+- **js/fruitConfig.js** – list of available fruits with image, score, size and
+  aspect ratio information.
 - **js/levelConfig.js** – game levels defining speed, duration, spawn rate and prioritized fruit choices.
 - **js/modeManager.js** – simple controller used to register and switch between modes.
 - **js/startMode.js** – displays the intro screen with live webcam feed. Cutting the start button with a fast hand movement begins the game.
 - **js/fruit.js** – small physics object representing a falling fruit.
 - **js/gameMode.js** – real‑time game loop that updates the timer, fruits and palm positions every frame.
 - **img/** – folder with fruit images. The `basic` entry in `js/fruitConfig.js`
-  provides the image used for the start button.
+  provides the image used for the start button. Each fruit definition includes an
+  aspect ratio so images are drawn without distortion.
 
 The code is written in small modules so that additional modes (for example a score screen or settings) can be added later by registering new mode classes with `ModeManager`.
 

--- a/js/fruit.js
+++ b/js/fruit.js
@@ -5,7 +5,11 @@ const ROTATION_SPEED_MIN = 0.03;
 const ROTATION_SPEED_MAX = 0.15;
 
 export default class Fruit {
-  constructor(image, x, y, vx, vy, radius, score = 1, canvasWidth = null) {
+  // Fruit represents a falling object drawn with its original aspect ratio.
+  // `width` and `height` are the display dimensions of the image. A
+  // `boundingRadius` is derived from the larger dimension for simplified
+  // collision checks and spawn offset.
+  constructor(image, x, y, vx, vy, width, height, score = 1, canvasWidth = null) {
     this.image = new Image();
     this.image.src = image;
     this.x = x;
@@ -15,7 +19,9 @@ export default class Fruit {
     this.vx = vx;
     this.vy = vy;
     this.gravity = 800; // px per second^2
-    this.radius = radius;
+    this.width = width;
+    this.height = height;
+    this.boundingRadius = Math.max(width, height) / 2;
     this.score = score;
     this.alive = true;
     this.highestY = null;
@@ -28,7 +34,7 @@ export default class Fruit {
     if (canvasWidth !== null) {
       const tPeak = -this.vy / this.gravity;
       this.highestY = this.y + this.vy * tPeak + 0.5 * this.gravity * tPeak ** 2;
-      const distX = canvasWidth + this.radius * 2;
+      const distX = canvasWidth + this.boundingRadius * 2;
       const tCross = distX / Math.abs(this.vx);
       this.endVy = this.vy + this.gravity * tCross;
     }
@@ -51,8 +57,8 @@ export default class Fruit {
     ctx.save();
     ctx.translate(this.x, this.y);
     ctx.rotate(this.angle);
-    ctx.drawImage(this.image, -this.radius, -this.radius,
-      this.radius * 2, this.radius * 2);
+    ctx.drawImage(this.image, -this.width / 2, -this.height / 2,
+      this.width, this.height);
     ctx.restore();
     // per-frame logs removed to avoid spam
   }

--- a/js/fruitConfig.js
+++ b/js/fruitConfig.js
@@ -3,25 +3,30 @@ export const FRUITS = {
     image: 'img/watermelon.png',
     score: 1,
     size: 0.15,
+    aspect: 0.946, // width / height
   },
   pineapple: {
     image: 'img/pineapple.png',
     score: 1,
     size: 0.2,
+    aspect: 0.607,
   },
   pear: {
     image: 'img/pear.png',
     score: 2,
     size: 0.15, // fraction of screen height
+    aspect: 0.771,
   },
   apple: {
     image: 'img/apple.png',
     score: 3,
     size: 0.12, // fraction of screen height
+    aspect: 1.027,
   },
   mandarine: {
     image: 'img/mandarine.png',
     score: 4,
     size: 0.08, // fraction of screen height
+    aspect: 1.111,
   },
 };

--- a/js/gameMode.js
+++ b/js/gameMode.js
@@ -74,7 +74,11 @@ export default class GameMode {
     // 2) choose a peak higher than the start
     // 3) pick a point where the fruit will cross the bottom
     //    (0.5-1.5 screen widths away) and derive velocities
-    const radius = this.canvas.height * (cfg.size / 2);
+    // Each fruit's display height is a fraction of the screen and the width
+    // is scaled by its aspect ratio so images are not distorted.
+    const height = this.canvas.height * cfg.size;
+    const width = height * cfg.aspect;
+    const radius = Math.max(width, height) / 2; // used as bounding circle
     const side = Math.random() < 0.5 ? 'left' : 'right';
     const x = side === 'left' ? -radius : this.canvas.width + radius;
 
@@ -103,7 +107,7 @@ export default class GameMode {
     const vx = (fallX - x) / tCross;
     const endVy = vy + g * tCross;
 
-    const fruit = new Fruit(cfg.image, x, startY, vx, vy, radius, cfg.score, this.canvas.width);
+    const fruit = new Fruit(cfg.image, x, startY, vx, vy, width, height, cfg.score, this.canvas.width);
     fruit.highestY = highestY;
     fruit.endVy = endVy;
 
@@ -122,7 +126,7 @@ export default class GameMode {
         const p2 = { x: h.x, y: h.y };
         const f1 = { x: f.prevX, y: f.prevY };
         const f2 = { x: f.x, y: f.y };
-        const radius = f.radius + palmR;
+        const radius = f.boundingRadius + palmR;
         if (segmentsClose(p1, p2, f1, f2, radius)) {
           f.alive = false;
           this.score += f.score;

--- a/js/levelCompleteMode.js
+++ b/js/levelCompleteMode.js
@@ -13,10 +13,12 @@ export default class LevelCompleteMode {
     this.levelLabel = document.getElementById('level-finished');
     this.scoreLabel = document.getElementById('final-score');
     this.continueFruit = document.getElementById('continue-fruit');
+    // Continue button uses the basic fruit image. Size is based on viewport
+    // height and width respects the image's aspect ratio so it appears natural.
     this.continueFruit.src = FRUITS.basic.image;
-    const size = `${FRUITS.basic.size * 100}vh`;
-    this.continueFruit.style.width = size;
-    this.continueFruit.style.height = size;
+    const h = FRUITS.basic.size * 100;
+    this.continueFruit.style.height = `${h}vh`;
+    this.continueFruit.style.width = `${h * FRUITS.basic.aspect}vh`;
     this.pose = new PoseProcessor(this.video, this.canvas);
     this.animationId = null;
     this.lastTime = 0;

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -10,11 +10,13 @@ export default class StartMode {
     this.video = document.getElementById('intro-video');
     this.canvas = document.getElementById('intro-canvas');
     this.startFruit = document.getElementById('start-fruit');
-    // Use the image and configured size of the basic fruit for the start button
+    // Use the image and configured size of the basic fruit for the start button.
+    // Height is specified relative to the viewport and the width keeps the
+    // image's aspect ratio so the fruit is not stretched.
     this.startFruit.src = FRUITS.basic.image;
-    const size = `${FRUITS.basic.size * 100}vh`;
-    this.startFruit.style.width = size;
-    this.startFruit.style.height = size;
+    const h = FRUITS.basic.size * 100;
+    this.startFruit.style.height = `${h}vh`;
+    this.startFruit.style.width = `${h * FRUITS.basic.aspect}vh`;
     this.pose = new PoseProcessor(this.video, this.canvas);
     this.animationId = null;
     this.lastTime = 0;


### PR DESCRIPTION
## Summary
- store width/height ratio for every fruit
- use aspect ratio when spawning fruits
- draw fruit images with original aspect
- size start and continue buttons without distortion
- mention aspect ratio field in README

## Testing
- `node --check js/fruit.js js/gameMode.js js/startMode.js js/levelCompleteMode.js js/fruitConfig.js`

------
https://chatgpt.com/codex/tasks/task_e_684a4e59a62c8326be8060bf1deed763