### PR TITLE
Reposition start fruit again

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,14 +44,14 @@
     }
     #start-fruit {
       position: absolute;
-      bottom: 5vh;
+      top: 20%;
       left: 50%;
       transform: translateX(-50%);
       pointer-events: none;
     }
     #start-text {
       position: absolute;
-      top: 35%;
+      top: 45%;
       width: 100%;
       text-align: center;
       color: #fff;
@@ -80,7 +80,7 @@
     }
     #complete-text {
       position: absolute;
-      top: 35%;
+      top: 45%;
       width: 100%;
       text-align: center;
       color: #fff;
@@ -95,7 +95,7 @@
     }
     #continue-fruit {
       position: absolute;
-      bottom: 5vh;
+      top: 20%;
       left: 50%;
       transform: translateX(-50%);
       pointer-events: none;


### PR DESCRIPTION
## Summary
- move start fruit to top 20% of start screen
- move continue fruit similarly and shift labels down to 45%

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ba0cd02dc83268395beddb293c899