### PR TITLE
Compute fruit aspect ratios dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ This repository now contains the initial structure of a pose‑controlled fruit 
 - **index.html** – loads external pose detection libraries and switches between different game modes.
 - **js/poseProcessor.js** – wrapper around pose detection library. Initializes the webcam stream and pose detector once and draws highlighted palms.
 - **js/config.js** – global configuration with a `DEBUG` flag, `USE_STUB` to simulate movement without a webcam and `ACTIVE_SPEED_FRACTION` controlling how fast a hand must move to become active.
-- **js/fruitConfig.js** – list of available fruits with image, score, size and
-  aspect ratio information.
+- **js/fruitConfig.js** – list of available fruits with image and size. Each
+  fruit's aspect ratio is measured when the image loads.
 - **js/levelConfig.js** – game levels defining speed, duration, spawn rate and prioritized fruit choices.
 - **js/modeManager.js** – simple controller used to register and switch between modes.
 - **js/startMode.js** – displays the intro screen with live webcam feed. Cutting the start button with a fast hand movement begins the game.
 - **js/fruit.js** – small physics object representing a falling fruit.
 - **js/gameMode.js** – real‑time game loop that updates the timer, fruits and palm positions every frame.
 - **img/** – folder with fruit images. The `basic` entry in `js/fruitConfig.js`
-  provides the image used for the start button. Each fruit definition includes an
-  aspect ratio so images are drawn without distortion.
+  provides the image used for the start button. Fruit images are loaded once at
+  startup to determine their aspect ratios so visuals render without distortion.
 
 The code is written in small modules so that additional modes (for example a score screen or settings) can be added later by registering new mode classes with `ModeManager`.
 

--- a/js/fruitConfig.js
+++ b/js/fruitConfig.js
@@ -3,42 +3,59 @@ export const FRUITS = {
     image: 'img/watermelon.png',
     score: 1,
     size: 0.15,
-    aspect: 0.946, // width / height
   },
   pineapple: {
     image: 'img/pineapple.png',
     score: 1,
     size: 0.2,
-    aspect: 0.607,
   },
   pear: {
     image: 'img/pear.png',
     score: 2,
     size: 0.15, // fraction of screen height
-    aspect: 0.771,
   },
   apple: {
     image: 'img/apple.png',
     score: 3,
     size: 0.12, // fraction of screen height
-    aspect: 1.027,
   },
   mandarine: {
     image: 'img/mandarine.png',
     score: 4,
     size: 0.08, // fraction of screen height
-    aspect: 1.111,
   },
   blueberry: {
     image: 'img/blueberry.png',
     score: 10,
     size: 0.05, // fraction of screen height
-    aspect: 1.,
   },
   robot: {
     image: 'img/robot.png',
     score: -10,
     size: 0.25, // fraction of screen height
-    aspect: 1.,
   },
 };
+
+// Loads fruit images to calculate their aspect ratios once.
+// Each fruit's aspect ratio is stored on the corresponding config
+// object to keep drawing logic simple across modes.
+let loadPromise = null;
+export function loadFruitAspects() {
+  if (loadPromise) return loadPromise;
+  loadPromise = Promise.all(Object.keys(FRUITS).map(key => new Promise(resolve => {
+    const cfg = FRUITS[key];
+    const img = new Image();
+    img.src = cfg.image;
+    if (img.complete) {
+      cfg.aspect = img.naturalWidth / img.naturalHeight;
+      resolve();
+    } else {
+      img.onload = () => {
+        cfg.aspect = img.naturalWidth / img.naturalHeight;
+        resolve();
+      };
+      img.onerror = () => resolve();
+    }
+  })));
+  return loadPromise;
+}

--- a/js/gameMode.js
+++ b/js/gameMode.js
@@ -2,6 +2,7 @@ import PoseProcessor from './poseProcessor.js';
 import Fruit from './fruit.js';
 import { DEBUG, debug } from './config.js';
 import { LEVELS, chooseFruit } from './levelConfig.js';
+import { loadFruitAspects } from './fruitConfig.js';
 import { segmentsClose } from './geometry.js';
 
 function samplePoisson(lambda) {
@@ -37,9 +38,11 @@ export default class GameMode {
     debug('GameMode created');
   }
 
+  // Enter prepares the webcam and loads fruit images so spawn calculations
+  // can use the correct aspect ratios for each fruit.
   async enter() {
     this.container.style.display = 'block';
-    await this.pose.init();
+    await Promise.all([this.pose.init(), loadFruitAspects()]);
     this.level = this.manager.level;
     const levelCfg = LEVELS[this.level];
     this.timeSpeed = levelCfg.speed;
@@ -75,7 +78,8 @@ export default class GameMode {
     // 3) pick a point where the fruit will cross the bottom
     //    (0.5-1.5 screen widths away) and derive velocities
     // Each fruit's display height is a fraction of the screen and the width
-    // is scaled by its aspect ratio so images are not distorted.
+    // is scaled by the aspect ratio measured from the loaded image so it
+    // appears without distortion.
     const height = this.canvas.height * cfg.size;
     const width = height * cfg.aspect;
     const radius = Math.max(width, height) / 2; // used as bounding circle

--- a/js/levelCompleteMode.js
+++ b/js/levelCompleteMode.js
@@ -1,5 +1,5 @@
 import PoseProcessor from './poseProcessor.js';
-import { FRUITS } from './fruitConfig.js';
+import { FRUITS, loadFruitAspects } from './fruitConfig.js';
 import { LEVELS } from './levelConfig.js';
 import { debug } from './config.js';
 import { segmentRectIntersect } from './geometry.js';
@@ -13,12 +13,9 @@ export default class LevelCompleteMode {
     this.levelLabel = document.getElementById('level-finished');
     this.scoreLabel = document.getElementById('final-score');
     this.continueFruit = document.getElementById('continue-fruit');
-    // Continue button uses the basic fruit image. Size is based on viewport
-    // height and width respects the image's aspect ratio so it appears natural.
+    // Continue button uses the basic fruit image. Dimensions are set once
+    // fruit images load so the aspect ratio remains natural.
     this.continueFruit.src = FRUITS.basic.image;
-    const h = FRUITS.basic.size * 100;
-    this.continueFruit.style.height = `${h}vh`;
-    this.continueFruit.style.width = `${h * FRUITS.basic.aspect}vh`;
     this.pose = new PoseProcessor(this.video, this.canvas);
     this.animationId = null;
     this.lastTime = 0;
@@ -27,9 +24,14 @@ export default class LevelCompleteMode {
     debug('LevelCompleteMode created');
   }
 
+  // Enter waits for fruit images so the continue button can scale
+  // to the correct aspect ratio before appearing.
   async enter() {
     this.container.style.display = 'block';
-    await this.pose.init();
+    await Promise.all([this.pose.init(), loadFruitAspects()]);
+    const h = FRUITS.basic.size * 100;
+    this.continueFruit.style.height = `${h}vh`;
+    this.continueFruit.style.width = `${h * FRUITS.basic.aspect}vh`;
     const levelNum = this.manager.level + 1;
     if (this.manager.level >= LEVELS.length - 1) {
       this.levelLabel.textContent = 'Game Complete';

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -1,6 +1,6 @@
 import PoseProcessor from './poseProcessor.js';
 import { DEBUG, debug } from './config.js';
-import { FRUITS } from './fruitConfig.js';
+import { FRUITS, loadFruitAspects } from './fruitConfig.js';
 import { segmentRectIntersect } from './geometry.js';
 
 export default class StartMode {
@@ -10,22 +10,23 @@ export default class StartMode {
     this.video = document.getElementById('intro-video');
     this.canvas = document.getElementById('intro-canvas');
     this.startFruit = document.getElementById('start-fruit');
-    // Use the image and configured size of the basic fruit for the start button.
-    // Height is specified relative to the viewport and the width keeps the
-    // image's aspect ratio so the fruit is not stretched.
+    // Use the image of the basic fruit for the start button. Dimensions are set
+    // once the fruit images have loaded and their aspect ratios are known.
     this.startFruit.src = FRUITS.basic.image;
-    const h = FRUITS.basic.size * 100;
-    this.startFruit.style.height = `${h}vh`;
-    this.startFruit.style.width = `${h * FRUITS.basic.aspect}vh`;
     this.pose = new PoseProcessor(this.video, this.canvas);
     this.animationId = null;
     this.lastTime = 0;
     debug('StartMode created');
   }
 
+  // Enter initializes the webcam and ensures fruit images are loaded so
+  // the start button can scale correctly using the fruit's aspect ratio.
   async enter() {
     this.container.style.display = 'block';
-    await this.pose.init();
+    await Promise.all([this.pose.init(), loadFruitAspects()]);
+    const h = FRUITS.basic.size * 100;
+    this.startFruit.style.height = `${h}vh`;
+    this.startFruit.style.width = `${h * FRUITS.basic.aspect}vh`;
     this.lastTime = performance.now();
     this.loop(this.lastTime);
     debug('StartMode enter');


### PR DESCRIPTION
## Summary
- remove hardcoded aspect ratios from config
- load images once and store computed aspect ratios
- size the start and continue buttons after images load
- load fruit aspects before starting game so spawns use correct dimensions
- document new behavior in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684bad27998c8326a0da4c517c0acefd