### PR TITLE
Fix start fruit display timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,11 +62,11 @@
     }
     #instruction-text {
       position: absolute;
-      top: 0;
+      top: 45%;
       width: 100%;
       text-align: center;
       color: #fff;
-      font-size: 3vh;
+      font-size: 5vh;
       background: rgba(0, 64, 0, 0.6);
       padding: 1vh;
       box-sizing: border-box;

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -10,6 +10,7 @@ export default class StartMode {
     this.video = document.getElementById('intro-video');
     this.canvas = document.getElementById('intro-canvas');
     this.startFruit = document.getElementById('start-fruit');
+    this.startText = document.getElementById('start-text');
     // Use the image of the basic fruit for the start button. Dimensions are set
     // once the fruit images have loaded and their aspect ratios are known.
     this.startFruit.src = FRUITS.basic.image;
@@ -19,14 +20,24 @@ export default class StartMode {
     debug('StartMode created');
   }
 
-  // Enter initializes the webcam and ensures fruit images are loaded so
-  // the start button can scale correctly using the fruit's aspect ratio.
+  // Enter initializes the webcam and pose detector. The start fruit and
+  // accompanying text remain hidden until the detector is ready so the
+  // player doesn't see the oversized image before we know its aspect
+  // ratio. Once everything is loaded we size the fruit correctly and
+  // reveal both elements.
   async enter() {
     this.container.style.display = 'block';
+    this.startFruit.style.visibility = 'hidden';
+    if (this.startText) this.startText.style.visibility = 'hidden';
+
     await Promise.all([this.pose.init(), loadFruitAspects()]);
+
     const h = FRUITS.basic.size * 100;
     this.startFruit.style.height = `${h}vh`;
     this.startFruit.style.width = `${h * FRUITS.basic.aspect}vh`;
+    this.startFruit.style.visibility = 'visible';
+    if (this.startText) this.startText.style.visibility = 'visible';
+
     this.lastTime = performance.now();
     this.loop(this.lastTime);
     debug('StartMode enter');

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -11,6 +11,7 @@ export default class StartMode {
     this.canvas = document.getElementById('intro-canvas');
     this.startFruit = document.getElementById('start-fruit');
     this.startText = document.getElementById('start-text');
+    this.instructionText = document.getElementById('instruction-text');
     // Use the image of the basic fruit for the start button. Dimensions are set
     // once the fruit images have loaded and their aspect ratios are known.
     this.startFruit.src = FRUITS.basic.image;
@@ -20,15 +21,17 @@ export default class StartMode {
     debug('StartMode created');
   }
 
-  // Enter initializes the webcam and pose detector. The start fruit and
-  // accompanying text remain hidden until the detector is ready so the
-  // player doesn't see the oversized image before we know its aspect
-  // ratio. Once everything is loaded we size the fruit correctly and
-  // reveal both elements.
+  // Enter initializes the webcam and pose detector. While they load we
+  // display a message telling the player to enable their webcam.
+  // The fruit and start text stay hidden so the user doesn't see the
+  // oversized fruit before its aspect ratio is known. Once everything
+  // is ready we hide the instruction text, size the fruit correctly and
+  // reveal the start message.
   async enter() {
     this.container.style.display = 'block';
     this.startFruit.style.visibility = 'hidden';
     if (this.startText) this.startText.style.visibility = 'hidden';
+    if (this.instructionText) this.instructionText.style.visibility = 'visible';
 
     await Promise.all([this.pose.init(), loadFruitAspects()]);
 
@@ -37,6 +40,7 @@ export default class StartMode {
     this.startFruit.style.width = `${h * FRUITS.basic.aspect}vh`;
     this.startFruit.style.visibility = 'visible';
     if (this.startText) this.startText.style.visibility = 'visible';
+    if (this.instructionText) this.instructionText.style.visibility = 'hidden';
 
     this.lastTime = performance.now();
     this.loop(this.lastTime);


### PR DESCRIPTION
## Summary
- hide the start fruit and text until the pose detector finishes loading
- size and reveal the fruit once the detector is ready

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852d5f04c5083268b10e18dbaa5390f