### PR TITLE
Improve new fruit preview layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
       left: 50%;
       transform: translateX(-50%);
       display: none;
-      flex-direction: column;
+      flex-direction: row;
       align-items: center;
       gap: 2vh;
       color: #fff;
@@ -119,10 +119,6 @@
       pointer-events: none;
     }
     #new-fruit-box img {
-      pointer-events: none;
-    }
-    #new-fruit-title {
-      font-size: 4vh;
       pointer-events: none;
     }
     #continue-text {
@@ -178,7 +174,6 @@
     <div id="continue-text">Slice the fruit to continue</div>
     <img id="continue-fruit" alt="Continue">
     <div id="new-fruit-box">
-      <div id="new-fruit-title">New fruit</div>
       <img id="new-fruit-img" alt="New">
       <span id="new-fruit-score"></span>
     </div>

--- a/js/levelCompleteMode.js
+++ b/js/levelCompleteMode.js
@@ -45,8 +45,9 @@ export default class LevelCompleteMode {
 
   // Enter waits for fruit images so the continue button can scale
   // to the correct aspect ratio before appearing. It also prepares the
-  // "new fruit" preview and hides the continue prompt until the player
-  // is allowed to proceed.
+  // preview of the next fruit as a horizontal layout of the image and
+  // its score and hides the continue prompt until the player is allowed
+  // to proceed.
   async enter() {
     this.container.style.display = 'block';
     await Promise.all([this.pose.init(), loadFruitAspects()]);
@@ -60,7 +61,10 @@ export default class LevelCompleteMode {
       this.newFruitImg.src = cfg.image;
       this.newFruitImg.style.height = `${nh}vh`;
       this.newFruitImg.style.width = `${nh * cfg.aspect}vh`;
-      this.newFruitScore.textContent = `+${cfg.score}`;
+      const score = cfg.score;
+      // Display a '+' only for positive scores so negative values are
+      // shown without a redundant sign.
+      this.newFruitScore.textContent = score > 0 ? `+${score}` : `${score}`;
       this.newFruitBox.style.display = 'flex';
     } else {
       this.newFruitBox.style.display = 'none';


### PR DESCRIPTION
## Summary
- lay out the new fruit preview horizontally
- hide the "New fruit" title element
- display negative scores without a plus sign

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856cd31be488326907046f7efc33783