### PR TITLE
Add slice-all fruit behaviour

### DIFF
--- a/js/fruit.js
+++ b/js/fruit.js
@@ -8,21 +8,28 @@ export default class Fruit {
   // Fruit represents a falling object drawn with its original aspect ratio.
   // `width` and `height` are the display dimensions of the image. A
   // `boundingRadius` is derived from the larger dimension for simplified
-  // collision checks and spawn offset.
-  constructor(image, x, y, vx, vy, width, height, score = 1, canvasWidth = null) {
-    this.image = new Image();
-    this.image.src = image;
+  // collision checks and spawn offset. The constructor accepts either an image
+  // URL or a preloaded Image object so callers can avoid repeated loads.
+  constructor(image, x, y, vx, vy, width, height, score = 1, canvasWidth = null, type = 'unknown', gravity = 800) {
+    // `image` may be a string URL or a preloaded Image object.
+    if (image instanceof HTMLImageElement) {
+      this.image = image;
+    } else {
+      this.image = new Image();
+      this.image.src = image;
+    }
     this.x = x;
     this.y = y;
     this.prevX = x;
     this.prevY = y;
     this.vx = vx;
     this.vy = vy;
-    this.gravity = 800; // px per second^2
+    this.gravity = gravity; // px per second^2
     this.width = width;
     this.height = height;
     this.boundingRadius = Math.max(width, height) / 2;
     this.score = score;
+    this.type = type;
     this.alive = true;
     this.highestY = null;
     this.endVy = null;

--- a/js/levelCompleteMode.js
+++ b/js/levelCompleteMode.js
@@ -62,9 +62,13 @@ export default class LevelCompleteMode {
       this.newFruitImg.style.height = `${nh}vh`;
       this.newFruitImg.style.width = `${nh * cfg.aspect}vh`;
       const score = cfg.score;
-      // Display a '+' only for positive scores so negative values are
-      // shown without a redundant sign.
-      this.newFruitScore.textContent = score > 0 ? `+${score}` : `${score}`;
+      if (cfg.scoreMessage) {
+        this.newFruitScore.textContent = cfg.scoreMessage;
+      } else {
+        // Display a '+' only for positive scores so negative values are
+        // shown without a redundant sign.
+        this.newFruitScore.textContent = score > 0 ? `+${score}` : `${score}`;
+      }
       this.newFruitBox.style.display = 'flex';
     } else {
       this.newFruitBox.style.display = 'none';

--- a/js/levelConfig.js
+++ b/js/levelConfig.js
@@ -104,14 +104,19 @@ export const LEVELS = [
   }, 
 ];
 
-// utility to pick a fruit based on priorities
+// chooseFruit returns a random fruit configuration for the given level. Each
+// level lists fruit types with associated spawn priorities. The returned object
+// also exposes the fruit type so game logic can trigger special behaviours.
 export function chooseFruit(level) {
   const list = LEVELS[level].fruits;
   const total = list.reduce((s, f) => s + f.priority, 0);
   let r = Math.random() * total;
   for (const f of list) {
-    if (r < f.priority) return FRUITS[f.type];
+    if (r < f.priority) {
+      return { ...FRUITS[f.type], type: f.type };
+    }
     r -= f.priority;
   }
-  return FRUITS[list[0].type];
+  const t = list[0].type;
+  return { ...FRUITS[t], type: t };
 }


### PR DESCRIPTION
## Summary
- create sliceAll config for the pomegranate entry
- load optional sliceAll piece images during preload
- rename `handlePomegranate` to generic `handleSliceAll`
- trigger slice-all effect when fruits with sliceAll config are cut
- show custom score message for special fruits
- remove placeholder image files

## Testing
- `node --check js/gameMode.js`
- `node --check js/fruitConfig.js`


------
https://chatgpt.com/codex/tasks/task_e_6860d40deed4832690856bc18ae5f4cf