### PR TITLE
Fix sliceAll pieces crash

### DIFF
--- a/js/gameMode.js
+++ b/js/gameMode.js
@@ -167,7 +167,10 @@ export default class GameMode {
           this.score += f.score;
           debug('Fruit cut', f);
           const cfg = FRUITS[f.type];
-          if (cfg.sliceAll) {
+          // Pieces spawned from a pomegranate explosion do not exist in
+          // the FRUITS config. Guard against undefined so they can be cut
+          // without crashing the game.
+          if (cfg && cfg.sliceAll) {
             this.handleSliceAll(f);
           } else {
             this.updateDisplay();


### PR DESCRIPTION
## Summary
- prevent null access when slicing pomegranate explosion pieces

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68696abf27d08326bee47817b6454b6b