### PR TITLE
Improve loading and final screen behavior

### DIFF
--- a/js/levelCompleteMode.js
+++ b/js/levelCompleteMode.js
@@ -47,7 +47,8 @@ export default class LevelCompleteMode {
   // to the correct aspect ratio before appearing. It also prepares the
   // preview of the next fruit as a horizontal layout of the image and
   // its score and hides the continue prompt until the player is allowed
-  // to proceed.
+  // to proceed. When the last level is complete the continue button is
+  // permanently hidden so the game cannot restart.
   async enter() {
     this.container.style.display = 'block';
     await Promise.all([this.pose.init(), loadFruitAspects()]);
@@ -74,7 +75,8 @@ export default class LevelCompleteMode {
       this.newFruitBox.style.display = 'none';
     }
     const levelNum = this.manager.level + 1;
-    if (this.manager.level >= LEVELS.length - 1) {
+    const isFinal = this.manager.level >= LEVELS.length - 1;
+    if (isFinal) {
       this.levelLabel.textContent = 'Game Complete';
     } else {
       this.levelLabel.textContent = `Level ${levelNum} finished`;
@@ -83,11 +85,18 @@ export default class LevelCompleteMode {
     this.continueFruit.style.visibility = 'hidden';
     this.continueText.style.visibility = 'hidden';
     this.buttonReady = false;
-    this.showTimeout = setTimeout(() => {
-      this.continueFruit.style.visibility = 'visible';
-      this.continueText.style.visibility = 'visible';
-      this.buttonReady = true;
-    }, 2000);
+    if (isFinal) {
+      this.continueFruit.style.display = 'none';
+      this.continueText.style.display = 'none';
+    } else {
+      this.continueFruit.style.display = 'block';
+      this.continueText.style.display = 'block';
+      this.showTimeout = setTimeout(() => {
+        this.continueFruit.style.visibility = 'visible';
+        this.continueText.style.visibility = 'visible';
+        this.buttonReady = true;
+      }, 2000);
+    }
     this.lastTime = performance.now();
     this.loop(this.lastTime);
     debug('LevelCompleteMode enter');
@@ -99,6 +108,8 @@ export default class LevelCompleteMode {
     clearTimeout(this.showTimeout);
     this.newFruitBox.style.display = 'none';
     this.continueText.style.visibility = 'hidden';
+    this.continueFruit.style.display = 'block';
+    this.continueText.style.display = 'block';
     this.pose.stop();
     debug('LevelCompleteMode exit');
   };

--- a/js/poseProcessor.js
+++ b/js/poseProcessor.js
@@ -13,12 +13,20 @@ export default class PoseProcessor {
     this.prevRight = null;
   }
 
-  async init() {
+  /**
+   * Initializes the webcam and pose detector.
+   * If a callback is provided it is called once the webcam
+   * stream is active but before the pose model finishes loading.
+   * This allows callers to show a loading state while the
+   * MoveNet model downloads.
+   */
+  async init(onVideoReady = null) {
     if (USE_STUB) {
       // use synthetic animation instead of webcam
       this.fakeT = 0;
       this.canvas.height = this.video.videoHeight || this.canvas.clientHeight;
       this.canvas.width = this.canvas.height * 4 / 3;
+      if (onVideoReady) onVideoReady();
       debug('PoseProcessor using stub');
     } else {
       if (!PoseProcessor.stream) {
@@ -39,6 +47,7 @@ export default class PoseProcessor {
 
       this.canvas.width = this.video.videoHeight * 4 / 3;
       this.canvas.height = this.video.videoHeight;
+      if (onVideoReady) onVideoReady();
     }
 
     // load external pose detection library (placeholder)

--- a/js/startMode.js
+++ b/js/startMode.js
@@ -12,6 +12,7 @@ export default class StartMode {
     this.startFruit = document.getElementById('start-fruit');
     this.startText = document.getElementById('start-text');
     this.instructionText = document.getElementById('instruction-text');
+    this.defaultInstruction = this.instructionText ? this.instructionText.textContent : '';
     // Use the image of the basic fruit for the start button. Dimensions are set
     // once the fruit images have loaded and their aspect ratios are known.
     this.startFruit.src = FRUITS.basic.image;
@@ -31,9 +32,18 @@ export default class StartMode {
     this.container.style.display = 'block';
     this.startFruit.style.visibility = 'hidden';
     if (this.startText) this.startText.style.visibility = 'hidden';
-    if (this.instructionText) this.instructionText.style.visibility = 'visible';
+    if (this.instructionText) {
+      this.instructionText.style.visibility = 'visible';
+      this.instructionText.textContent = this.defaultInstruction;
+    }
 
-    await Promise.all([this.pose.init(), loadFruitAspects()]);
+    // Update the instructions once the webcam stream is active but
+    // before the pose model loads so players see a loading message.
+    const onReady = () => {
+      if (this.instructionText) this.instructionText.textContent = 'loading...';
+    };
+
+    await Promise.all([this.pose.init(onReady), loadFruitAspects()]);
 
     const h = FRUITS.basic.size * 100;
     this.startFruit.style.height = `${h}vh`;
@@ -51,6 +61,7 @@ export default class StartMode {
     this.container.style.display = 'none';
     cancelAnimationFrame(this.animationId);
     this.pose.stop();
+    if (this.instructionText) this.instructionText.textContent = this.defaultInstruction;
     debug('StartMode exit');
   };
 


### PR DESCRIPTION
## Summary
- show default text and switch to `loading...` when webcam starts
- allow UI to show loading before pose model is ready
- hide continue button on the final screen so the game can't restart

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cb1c805c08326bbbc1d9aba1d9136